### PR TITLE
Naycoma/issue1

### DIFF
--- a/1.5/Source/Compat.cs
+++ b/1.5/Source/Compat.cs
@@ -1,8 +1,13 @@
+using System.Collections.Generic;
+
 using UnityEngine;
+using RimWorld;
 
 namespace GoodwillPreview;
 
 internal static class Compat {
     public static Rect MiddlePartPixels(this Rect rect, float width, float height) =>
         new(rect.center.x - width / 2f, rect.center.y - height / 2f, width, height);
+
+    public static bool IsShuttle(this List<CompTransporter> transporters) => false;
 }

--- a/1.5/Source/Compat.cs
+++ b/1.5/Source/Compat.cs
@@ -1,16 +1,8 @@
 using UnityEngine;
 
-using RimWorld;
-
 namespace GoodwillPreview;
 
 internal static class Compat {
-    public static float GetMaxFuelLevel(this CompLaunchable launcher) =>
-        launcher.FuelingPortSource?.GetComp<CompRefuelable>()?.Props.fuelCapacity ?? 0f;
-
-    public static int MaxLaunchDistanceAtFuelLevel(this CompLaunchable _, float fuelLevel) =>
-        CompLaunchable.MaxLaunchDistanceAtFuelLevel(fuelLevel);
-
     public static Rect MiddlePartPixels(this Rect rect, float width, float height) =>
         new(rect.center.x - width / 2f, rect.center.y - height / 2f, width, height);
 }

--- a/1.6/Source/Compat.cs
+++ b/1.6/Source/Compat.cs
@@ -1,8 +1,5 @@
-using RimWorld;
-
 namespace GoodwillPreview;
 
 internal static class Compat {
-    public static float GetMaxFuelLevel(this CompLaunchable launcher) =>
-        launcher.MaxFuelLevel;
+
 }

--- a/Common/Source/Mod.cs
+++ b/Common/Source/Mod.cs
@@ -90,6 +90,8 @@ public static class Mod {
 
     public static bool Empty() => dialog == null || settlements.Empty();
 
+    public static bool IsShuttle() => dialog.transporters?.IsShuttle() ?? true;
+
     public static void ChangedFaction() {
         singlePriceDirty = true;
     }

--- a/Common/Source/Mod.cs
+++ b/Common/Source/Mod.cs
@@ -1,13 +1,12 @@
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using UnityEngine;
 using Verse;
 using RimWorld;
-
 using RimWorld.Planet;
-using System;
-using System.Diagnostics;
 
 namespace GoodwillPreview;
 

--- a/Common/Source/Mod.cs
+++ b/Common/Source/Mod.cs
@@ -7,6 +7,7 @@ using RimWorld;
 
 using RimWorld.Planet;
 using System;
+using System.Diagnostics;
 
 namespace GoodwillPreview;
 
@@ -53,6 +54,9 @@ public static class Mod {
     private static readonly List<Settlement> settlements = [];
 
     private static readonly Dictionary<Faction, int> goodwillsCache = [];
+    
+    private static bool singlePriceDirty = true;
+    private static readonly Dictionary<Thing, float> singlePriceCache = [];
     private static bool extraInfoDirty = true;
     private static TransferableUIUtility.ExtraInfo? extraInfoCache = null;
 
@@ -60,7 +64,9 @@ public static class Mod {
     private static readonly Color OurMarker = new(0f, 1f / 255f, 2f / 255f, 3f / 255f);
     private static int selectedIndex = -1;
 
-    public static void Open(Dialog_LoadTransporters dialog) => Mod.dialog = dialog;
+    public static void Open(Dialog_LoadTransporters dialog) {
+        Mod.dialog = dialog;
+    }
 
     public static void Close() => dialog = null;
 
@@ -75,7 +81,18 @@ public static class Mod {
         // Clamp selectedIndex to avoid out-of-range after settlements change
         CurrentSettlement();
     }
+
+    public static void ReloadSinglePrices() {
+        singlePriceDirty = false;
+        singlePriceCache.Clear();
+        TransferableFactionGiftUtility.CalculateGoodwillChange(dialog.transferables, CurrentSettlement(), singlePriceCache);
+    }
+
     public static bool Empty() => dialog == null || settlements.Empty();
+
+    public static void ChangedFaction() {
+        singlePriceDirty = true;
+    }
 
     public static void ChangedCount() {
         goodwillsCache.Clear();
@@ -84,7 +101,7 @@ public static class Mod {
 
     public static int TransferableGoodwill(Settlement settlement) {
         if (goodwillsCache.TryGetValue(settlement.Faction, out int goodwill)) return goodwill;
-        goodwill = settlement.GoodwillDeltaFor(dialog.transferables);
+        goodwill = settlement.GoodwillDeltaFor(dialog.transferables, singlePriceCache);
         return goodwillsCache[settlement.Faction] = goodwill;
     }
 
@@ -128,6 +145,9 @@ public static class Mod {
         if (!extraInfoDirty && extraInfoCache != null) return extraInfoCache;
         extraInfoDirty = false;
         if (Empty()) return extraInfoCache = null;
+        Stopwatch sw = Stopwatch.StartNew();
+
+        if (singlePriceDirty) ReloadSinglePrices();
 
         string tip = includeTip ? BuildTip() : "";
         var (current, next, delta) = TransferableGoodwillXtoY(CurrentSettlement());
@@ -137,10 +157,12 @@ public static class Mod {
             delta.ToStringWithSign().Named("DELTA")
         ).Resolve();
         // keyは空にしてPostfixでアイコン+Truncateテキストを自前描画
-        return extraInfoCache = new("", value, Color.white, tip, -9999f) {
+        extraInfoCache = new("", value, Color.white, tip, -9999f) {
             // secondValueが空の場合secondColorは未使用なのでマーカーとして流用
             secondColor = OurMarker
         };
+        if (Patch.DEBUG) Log.Message($"[{nameof(ExtraInfo)}] Built ExtraInfo in {sw.ElapsedMilliseconds} ms");
+        return extraInfoCache;
     }
 
     public static bool IsMarkedExtraInfo(TransferableUIUtility.ExtraInfo info) => info.secondColor == OurMarker;

--- a/Common/Source/Patch.cs
+++ b/Common/Source/Patch.cs
@@ -21,21 +21,16 @@ public static class Patch {
     [HarmonyPatch(nameof(Dialog_LoadTransporters.PostOpen)), HarmonyPostfix]
     public static void PostOpen_Postfix(Dialog_LoadTransporters __instance) {
         if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.PostOpen)}][Postfix] Dialog opened");
+        Mod.Open(__instance);
         int tile = __instance.map.Tile;
         Mod.ReloadSettlements(SettlementUtility.GetSettlementsWithinRadius(tile));
-    }
-
-    [HarmonyPatch(typeof(Dialog_LoadTransporters))]
-    [HarmonyPatch(nameof(Dialog_LoadTransporters.DoWindowContents)), HarmonyPrefix]
-    public static void DoWindowContents_Prefix(Dialog_LoadTransporters __instance) {
-        if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.DoWindowContents)}][Prefix] Window contents initialized");
-        Mod.Open(__instance);
+        Mod.ReloadSinglePrices();
     }
 
     [HarmonyPatch(typeof(TransferableUIUtility))]
     [HarmonyPatch(nameof(TransferableUIUtility.DrawExtraInfo)), HarmonyPrefix]
     public static void DrawExtraInfo_Prefix(ref List<TransferableUIUtility.ExtraInfo> info, ref Rect rect) {
-        if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Prefix] Initial info count: {info.Count}");
+        // if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Prefix] Initial info count: {info.Count}");
         if (Mod.Empty()) return;
         bool showFloatMenu = Find.WindowStack.Windows.Any(w => w is FloatMenu);
         if (Mod.ExtraInfo(includeTip: !showFloatMenu) is { } e)
@@ -45,7 +40,7 @@ public static class Patch {
     [HarmonyPatch(typeof(TransferableUIUtility))]
     [HarmonyPatch(nameof(TransferableUIUtility.DrawExtraInfo)), HarmonyPostfix]
     public static void DrawExtraInfo_Postfix(List<TransferableUIUtility.ExtraInfo> info, Rect rect) {
-        if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Postfix] Info count: {info.Count}");
+        // if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Postfix] Info count: {info.Count}");
         if (Mod.Empty()) return;
         float maxWidth = info.Count * 230f;
         if (rect.width > maxWidth)
@@ -74,10 +69,11 @@ public static class Patch {
         Mod.ChangedCount();
     }
 
-    [HarmonyPatch(typeof(Dialog_LoadTransporters))]
-    [HarmonyPatch(nameof(Dialog_LoadTransporters.DoWindowContents)), HarmonyPostfix]
-    public static void DoWindowContents_Postfix(Dialog_LoadTransporters __instance) {
-        if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.DoWindowContents)}][Postfix] Window contents drawn");
+    [HarmonyPatch(typeof(Window), nameof(Window.Close), [typeof(bool)])]
+    [HarmonyPostfix]
+    public static void Close_Postfix(Window __instance, bool doCloseSound) {
+        if (__instance is not Dialog_LoadTransporters) return;
+        if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.Close)}][Postfix] {__instance.GetHashCode()}");
         Mod.Close();
     }
 }

--- a/Common/Source/Patch.cs
+++ b/Common/Source/Patch.cs
@@ -32,6 +32,8 @@ public static class Patch {
     public static void DrawExtraInfo_Prefix(ref List<TransferableUIUtility.ExtraInfo> info, ref Rect rect) {
         // if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Prefix] Initial info count: {info.Count}");
         if (Mod.Empty()) return;
+        if (Mod.IsShuttle()) return;
+
         bool showFloatMenu = Find.WindowStack.Windows.Any(w => w is FloatMenu);
         if (Mod.ExtraInfo(includeTip: !showFloatMenu) is { } e)
             info.Add(e);
@@ -42,22 +44,22 @@ public static class Patch {
     public static void DrawExtraInfo_Postfix(List<TransferableUIUtility.ExtraInfo> info, Rect rect) {
         // if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Postfix] Info count: {info.Count}");
         if (Mod.Empty()) return;
+        if (Mod.IsShuttle()) return;
+
         float maxWidth = info.Count * 230f;
         if (rect.width > maxWidth)
             rect = rect.MiddlePartPixels(maxWidth, rect.height);
 
+        int markedIndex = info.FindIndex(Mod.IsMarkedExtraInfo);
+        if (markedIndex == -1) return;
+
         Widgets.BeginGroup(rect);
         rect = rect.AtZero();
 
-        int markedIndex = info.FindIndex(Mod.IsMarkedExtraInfo);
-        if (markedIndex >= 0) {
-            Faction displayed = Mod.CurrentSettlement().Faction;
-
-            Rect infoRect = rect.RightPart(1f - (float)markedIndex / info.Count);
-
-            if (Mod.ButtonGoodwillExtraInfo(infoRect, displayed))
-                Find.WindowStack.Add(Mod.CreateDropdownMenu());
-        }
+        Rect infoRect = rect.RightPart(1f - (float)markedIndex / info.Count);
+        Faction displayed = Mod.CurrentSettlement().Faction;
+        if (Mod.ButtonGoodwillExtraInfo(infoRect, displayed))
+            Find.WindowStack.Add(Mod.CreateDropdownMenu());
 
         Widgets.EndGroup();
     }

--- a/Common/Source/Patch.cs
+++ b/Common/Source/Patch.cs
@@ -10,26 +10,32 @@ namespace GoodwillPreview;
 
 [HarmonyPatch]
 public static class Patch {
+    public const bool DEBUG =
+#if DEBUG
+    true;
+# else
+    false;
+# endif
+
     [HarmonyPatch(typeof(Dialog_LoadTransporters))]
     [HarmonyPatch(nameof(Dialog_LoadTransporters.PostOpen)), HarmonyPostfix]
     public static void PostOpen_Postfix(Dialog_LoadTransporters __instance) {
-        // CompLaunchable launcher = __instance.transporters[0].Launchable;
-        // int distance = launcher.MaxLaunchDistanceAtFuelLevel(launcher.GetMaxFuelLevel());
+        if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.PostOpen)}][Postfix] Dialog opened");
         int tile = __instance.map.Tile;
-        // Log.Message($"Tile: {tile}, Radius: {distance}");
-        // Log.Message($"Transporters: {__instance.transporters.Count}");
         Mod.ReloadSettlements(SettlementUtility.GetSettlementsWithinRadius(tile));
     }
 
     [HarmonyPatch(typeof(Dialog_LoadTransporters))]
     [HarmonyPatch(nameof(Dialog_LoadTransporters.DoWindowContents)), HarmonyPrefix]
     public static void DoWindowContents_Prefix(Dialog_LoadTransporters __instance) {
+        if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.DoWindowContents)}][Prefix] Window contents initialized");
         Mod.Open(__instance);
     }
 
     [HarmonyPatch(typeof(TransferableUIUtility))]
     [HarmonyPatch(nameof(TransferableUIUtility.DrawExtraInfo)), HarmonyPrefix]
     public static void DrawExtraInfo_Prefix(ref List<TransferableUIUtility.ExtraInfo> info, ref Rect rect) {
+        if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Prefix] Initial info count: {info.Count}");
         if (Mod.Empty()) return;
         bool showFloatMenu = Find.WindowStack.Windows.Any(w => w is FloatMenu);
         if (Mod.ExtraInfo(includeTip: !showFloatMenu) is { } e)
@@ -39,6 +45,7 @@ public static class Patch {
     [HarmonyPatch(typeof(TransferableUIUtility))]
     [HarmonyPatch(nameof(TransferableUIUtility.DrawExtraInfo)), HarmonyPostfix]
     public static void DrawExtraInfo_Postfix(List<TransferableUIUtility.ExtraInfo> info, Rect rect) {
+        if (DEBUG) Log.Message($"[{nameof(TransferableUIUtility.DrawExtraInfo)}][Postfix] Info count: {info.Count}");
         if (Mod.Empty()) return;
         float maxWidth = info.Count * 230f;
         if (rect.width > maxWidth)
@@ -50,9 +57,9 @@ public static class Patch {
         int markedIndex = info.FindIndex(Mod.IsMarkedExtraInfo);
         if (markedIndex >= 0) {
             Faction displayed = Mod.CurrentSettlement().Faction;
-            
+
             Rect infoRect = rect.RightPart(1f - (float)markedIndex / info.Count);
-            
+
             if (Mod.ButtonGoodwillExtraInfo(infoRect, displayed))
                 Find.WindowStack.Add(Mod.CreateDropdownMenu());
         }
@@ -63,12 +70,14 @@ public static class Patch {
     [HarmonyPatch(typeof(Dialog_LoadTransporters))]
     [HarmonyPatch(nameof(Dialog_LoadTransporters.CountToTransferChanged)), HarmonyPostfix]
     public static void CountToTransferChanged_Postfix(Dialog_LoadTransporters __instance) {
+        if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.CountToTransferChanged)}][Postfix] Count changed");
         Mod.ChangedCount();
     }
 
     [HarmonyPatch(typeof(Dialog_LoadTransporters))]
     [HarmonyPatch(nameof(Dialog_LoadTransporters.DoWindowContents)), HarmonyPostfix]
     public static void DoWindowContents_Postfix(Dialog_LoadTransporters __instance) {
+        if (DEBUG) Log.Message($"[{nameof(Dialog_LoadTransporters.DoWindowContents)}][Postfix] Window contents drawn");
         Mod.Close();
     }
 }

--- a/Common/Source/Utilities.cs
+++ b/Common/Source/Utilities.cs
@@ -6,6 +6,7 @@ using Verse;
 using RimWorld;
 
 using RimWorld.Planet;
+using System.Diagnostics;
 
 namespace GoodwillPreview;
 
@@ -13,28 +14,9 @@ public static class FactionExtensions {
     public static string ColorGoodwill(this FactionRelationKind kind, int goodwill) {
         return goodwill.ToStringWithSign().Colorize(kind.GetColor());
     }
+
     public static string ColorLabel(this FactionRelationKind kind) {
         return kind.GetLabelCap().Colorize(kind.GetColor());
-    }
-}
-
-public static class TransferableFactionGiftUtility {
-    public static int CalculateGoodwillChange(List<TransferableOneWay> transferables, Settlement giveTo) {
-        float num = 0f;
-        foreach (TransferableOneWay transferable in transferables) {
-            TransferableUtility.TransferNoSplit(transferable.things, transferable.CountToTransfer, delegate (Thing originalThing, int toTake) {
-                float singlePrice;
-                if (originalThing.def == ThingDefOf.Silver) {
-                    singlePrice = originalThing.MarketValue;
-                } else {
-                    float priceFactorSell_TraderPriceType = (giveTo.TraderKind != null) ? giveTo.TraderKind.PriceTypeFor(originalThing.def, TradeAction.PlayerSells).PriceMultiplier() : 1f;
-                    singlePrice = TradeUtility.GetPricePlayerSell(originalThing, priceFactorSell_TraderPriceType, 1f, 0f, giveTo.TradePriceImprovementOffsetForPlayer, 0f, 0f);
-                }
-
-                num += FactionGiftUtility.GetBaseGoodwillChange(originalThing, toTake, singlePrice, giveTo.Faction);
-            }, removeIfTakingEntireThing: false, errorIfNotEnoughThings: false);
-        }
-        return FactionGiftUtility.PostProcessedGoodwillChange(num, giveTo.Faction);
     }
 
     public static FactionRelationKind NextKind(this Faction faction, int giveTo, out int newGoodwill) {
@@ -49,9 +31,52 @@ public static class TransferableFactionGiftUtility {
     }
 }
 
+public static class TransferableFactionGiftUtility {
+    // ref FactionGiftUtility.GetGoodwillChange
+    public static int GetGoodwillChange(IEnumerable<ThingCount> thingCounts, Settlement giveTo, Dictionary<Thing, float> singlePricesCache) {
+        float num = 0f;
+        foreach (var (thing, count) in thingCounts.Select(tc => (tc.thing, tc.Count))) {
+            if (!singlePricesCache.TryGetValue(thing, out float singlePrice))
+                singlePricesCache[thing] = singlePrice = GetSinglePrice(thing, giveTo);
+            num += FactionGiftUtility.GetBaseGoodwillChange(thing, count, singlePrice, giveTo.Faction);
+        }
+        return FactionGiftUtility.PostProcessedGoodwillChange(num, giveTo.Faction);
+    }
+    
+    // ref FactionGiftUtility.GetGoodwillChange
+    public static float GetSinglePrice(Thing thing, Settlement giveTo) {
+        if (thing.def == ThingDefOf.Silver) return thing.MarketValue;
+
+        float priceFactorSell_TraderPriceType = (giveTo.TraderKind != null) ? giveTo.TraderKind.PriceTypeFor(thing.def, TradeAction.PlayerSells).PriceMultiplier() : 1f;
+        return TradeUtility.GetPricePlayerSell(thing, priceFactorSell_TraderPriceType, 1f, 0f, giveTo.TradePriceImprovementOffsetForPlayer, 0f, 0f);
+    }
+
+    private static readonly List<ThingCount> tmpThingCounts = [];
+
+    public static int CalculateGoodwillChange(List<TransferableOneWay> transferables, Settlement giveTo, Dictionary<Thing, float> singlePricesCache) {
+        Stopwatch sw = Stopwatch.StartNew();
+        tmpThingCounts.Clear();
+        foreach (TransferableOneWay transferable in transferables) {
+            TransferableUtility.TransferNoSplit(transferable.things, transferable.CountToTransfer, delegate (Thing originalThing, int toTake) {
+                if (toTake <= 0) return;
+                tmpThingCounts.Add(new ThingCount(originalThing, toTake));
+            }, removeIfTakingEntireThing: false, errorIfNotEnoughThings: false);
+        }
+        foreach (Thing thing in tmpThingCounts.Select(tc => tc.thing)) {
+            if (singlePricesCache.ContainsKey(thing)) continue;
+            singlePricesCache[thing] = GetSinglePrice(thing, giveTo);
+        }
+        int result = GetGoodwillChange(tmpThingCounts, giveTo, singlePricesCache);
+        sw.Stop();
+        if (Patch.DEBUG) Log.Message($"[{nameof(CalculateGoodwillChange)}] Calculated goodwill change: ${result} in {sw.ElapsedMilliseconds} ms");
+        tmpThingCounts.Clear();
+        return result;
+    }
+}
+
 public static class SettlementUtility {
-    public static int GoodwillDeltaFor(this Settlement giveTo, List<TransferableOneWay> gifts) {
-        int goodwillChange = TransferableFactionGiftUtility.CalculateGoodwillChange(gifts, giveTo);
+    public static int GoodwillDeltaFor(this Settlement giveTo, List<TransferableOneWay> gifts, Dictionary<Thing, float> singlePricesCache) {
+        int goodwillChange = TransferableFactionGiftUtility.CalculateGoodwillChange(gifts, giveTo, singlePricesCache);
         int current = giveTo.Faction.PlayerGoodwill;
         int next = Mathf.Clamp(current + goodwillChange, -100, 100);
         return next - current;
@@ -70,10 +95,8 @@ public static class SettlementUtility {
     }
 }
 
-public static class EnumerableExtensions
-{
-    public static IEnumerable<(T item, int index)> Index<T>(this IEnumerable<T> source)
-    {
+public static class EnumerableExtensions {
+    public static IEnumerable<(T item, int index)> Index<T>(this IEnumerable<T> source) {
         int i = 0;
         foreach (var item in source) yield return (item, i++);
     }

--- a/build-autodetect.ps1
+++ b/build-autodetect.ps1
@@ -1,3 +1,7 @@
+param(
+    [switch]$DebugBuild
+)
+
 $steamPath = (Get-ItemProperty "HKCU:\Software\Valve\Steam").SteamPath
 $vdf = Get-Content "$steamPath/steamapps/libraryfolders.vdf" -Raw
 $paths = [regex]::Matches($vdf, '"path"\s+"([^"]+)"') | ForEach-Object {
@@ -20,6 +24,8 @@ $localModsPath = Join-Path $rimWorldPath "Mods"
 Write-Host "RimWorldPath:  $rimWorldPath"
 Write-Host "LocalModsPath: $localModsPath"
 
+$config = if ($DebugBuild) { "Debug" } else { "Release" }
 dotnet build "$PSScriptRoot/mod.csproj" `
+    -c $config `
     -p:RimWorldPath="$rimWorldPath" `
     -p:LocalModsPath="$localModsPath"


### PR DESCRIPTION
詳細は #1

- [x] 単位価格をキャッシュするように
- [x] シャトル搭載画面ではPatchしないようにする

Pawn搭載時に`Dialog_LoadTransporters.CalculateAndRecacheTransferables()`が重くなるバニラのバグにまでは手出ししない方向で。オーバーホール系MODではないのでひとまず。

1.6でシャトル使う機会も増えただろうしunstableの中で修正されることを願おう